### PR TITLE
Added DeleteBillingAccountTransaction

### DIFF
--- a/stargate/customer/billing/account/transaction/v1beta1/customer_billing_account_transaction_service.proto
+++ b/stargate/customer/billing/account/transaction/v1beta1/customer_billing_account_transaction_service.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 service CustomerBillingAccountTransactionService {
   rpc ListBillingAccountTransactions (ListBillingAccountTransactionsRequest) returns (stream ListBillingAccountTransactionsResponse) {}
   rpc CreateBillingAccountTransaction (CreateBillingAccountTransactionRequest) returns (CreateBillingAccountTransactionResponse) {}
+  rpc DeleteBillingAccountTransaction (DeleteBillingAccountTransactionRequest) returns (DeleteBillingAccountTransactionResponse) {}
 }
 
 message ListBillingAccountTransactionsRequest {
@@ -47,4 +48,12 @@ message CreateBillingAccountTransactionRequest {
 
 message CreateBillingAccountTransactionResponse {
   int64 id = 1;
+}
+
+message DeleteBillingAccountTransactionRequest {
+  int64 id = 1;
+}
+
+message DeleteBillingAccountTransactionResponse {
+
 }


### PR DESCRIPTION
This pull request introduces a new RPC method for deleting billing account transactions in the `CustomerBillingAccountTransactionService`. The most important changes include the addition of the `DeleteBillingAccountTransaction` RPC method and the creation of request and response messages for this method.

New RPC method:

* Added `DeleteBillingAccountTransaction` RPC method to `CustomerBillingAccountTransactionService` in `stargate/customer/billing/account/transaction/v1beta1/customer_billing_account_transaction_service.proto`.

New message definitions:

* Added `DeleteBillingAccountTransactionRequest` message with an `id` field in `stargate/customer/billing/account/transaction/v1beta1/customer_billing_account_transaction_service.proto`.
* Added empty `DeleteBillingAccountTransactionResponse` message in `stargate/customer/billing/account/transaction/v1beta1/customer_billing_account_transaction_service.proto`.